### PR TITLE
Disable cache support until shared cache is possible

### DIFF
--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -166,6 +166,9 @@ class BaseRecord(BaseModel):
             value: The value to cache
             ttl: The cache ttl
         """
+        # FIXME: Disable cache support until shared cache is possible in multiple aca-py servers environments
+        return
+
         if not cache_key:
             return
         cache: BaseCache = await context.inject(BaseCache, required=False)


### PR DESCRIPTION
Disable cache support until shared cache is possible in multiple aca-py servers environments

Signed-off-by: Ethan Sung <baegjae@gmail.com>