### PR TITLE
Fix error when registering nym

### DIFF
--- a/aries_cloudagent/ledger/routes.py
+++ b/aries_cloudagent/ledger/routes.py
@@ -8,7 +8,7 @@ from marshmallow import fields, validate
 from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import ENDPOINT_TYPE, INDY_DID, INDY_RAW_PUBLIC_KEY, INT_EPOCH
 from ..storage.error import StorageError
-from ..wallet.error import WalletError
+from ..wallet.error import WalletError, WalletNotFoundError
 
 from .base import BaseLedger
 from .endpoint_type import EndpointType
@@ -151,6 +151,8 @@ async def register_ledger_nym(request: web.BaseRequest):
             raise web.HTTPForbidden(reason=err.roll_up)
         except LedgerError as err:
             raise web.HTTPBadRequest(reason=err.roll_up)
+        except WalletNotFoundError as err:
+            raise web.HTTPBadRequest(reason=f"Requested wallet_name {wallet_name} is not exist: {err.roll_up}")
         except WalletError as err:
             raise web.HTTPBadRequest(
                 reason=(


### PR DESCRIPTION
In multitenancy, when registering nym, the wallet_name parameter is optionally used to register the DID of wallet_name's wallet.
This PR fixes the error cases below.

1. Fix an error when getting wallet_name's wallet while the wallet was not loaded
(Note that on demand wallet loading was applied)
2. Handle an exception when given wallet_name is not exist in storage

Signed-off-by: Ethan Sung baegjae@gmail.com