### PR TITLE
Feature/move did ssw

### DIFF
--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -21,6 +21,7 @@ from ..indy.issuer import IndyIssuer, IndyIssuerError, DEFAULT_CRED_DEF_TAG
 from ..indy.sdk.error import IndyErrorHandler
 from ..messaging.credential_definitions.util import CRED_DEF_SENT_RECORD_TYPE
 from ..messaging.schemas.util import SCHEMA_SENT_RECORD_TYPE
+from ..messaging.valid import DID_PREFIX
 from ..storage.base import StorageRecord
 from ..storage.indy import IndySdkStorage
 from ..utils import sentinel
@@ -930,7 +931,7 @@ class IndySdkLedger(BaseLedger):
         if nym:
             # remove any existing prefix
             nym = self.did_to_nym(nym)
-            return f"did:sov:{nym}"
+            return f"{DID_PREFIX}:{nym}"
 
     async def rotate_public_did_keypair(self, next_seed: str = None) -> None:
         """

--- a/aries_cloudagent/messaging/tests/test_valid.py
+++ b/aries_cloudagent/messaging/tests/test_valid.py
@@ -34,7 +34,7 @@ from ..valid import (
     JWT,
     SHA256,
     UUID4,
-    WHOLE_NUM,
+    WHOLE_NUM, DID_PREFIX,
 )
 
 
@@ -104,7 +104,7 @@ class TestValid(TestCase):
             "Q4zqM7aXqm7gDQkUVLng9I",  # 'I' not a base58 char
             "Q4zqM7aXqm7gDQkUVLng",  # too short
             "Q4zqM7aXqm7gDQkUVLngZZZ",  # too long
-            "did:sov:Q4zqM7aXqm7gDQkUVLngZZZ",  # too long
+            f"{DID_PREFIX}:Q4zqM7aXqm7gDQkUVLngZZZ",  # too long
             "did:other:Q4zqM7aXqm7gDQkUVLng9h",  # specifies non-indy DID
         ]
         for non_indy_did in non_indy_dids:
@@ -112,7 +112,7 @@ class TestValid(TestCase):
                 INDY_DID["validate"](non_indy_did)
 
         INDY_DID["validate"]("Q4zqM7aXqm7gDQkUVLng9h")  # TODO: accept non-indy dids
-        INDY_DID["validate"]("did:sov:Q4zqM7aXqm7gDQkUVLng9h")
+        INDY_DID["validate"](f"{DID_PREFIX}:Q4zqM7aXqm7gDQkUVLng9h")
 
     def test_indy_raw_public_key(self):
         non_indy_raw_public_keys = [
@@ -129,7 +129,7 @@ class TestValid(TestCase):
     def test_jws_header_kid(self):
         non_kids = [
             "http://not-this.one",
-            "did:sov:i",  # too short
+            f"{DID_PREFIX}:i",  # too short
             "did:key:Q4zqM7aXqm7gDQkUVLng9h"  # missing leading z
             "did:key:zI4zqM7aXqm7gDQkUVLng9h",  # 'I' not a base58 char
         ]
@@ -138,15 +138,15 @@ class TestValid(TestCase):
                 JWS_HEADER_KID["validate"](non_kid)
 
         JWS_HEADER_KID["validate"]("did:key:zQ4zqM7aXqm7gDQkUVLng9h")
-        JWS_HEADER_KID["validate"]("did:sov:Q4zqM7aXqm7gDQkUVLng9h#abc-123")
+        JWS_HEADER_KID["validate"](f"{DID_PREFIX}:Q4zqM7aXqm7gDQkUVLng9h#abc-123")
         JWS_HEADER_KID["validate"](
-            "did:sov:Q4zqM7aXqm7gDQkUVLng9h?version-time=1234567890#abc-123"
+            f"{DID_PREFIX}:Q4zqM7aXqm7gDQkUVLng9h?version-time=1234567890#abc-123"
         )
         JWS_HEADER_KID["validate"](
-            "did:sov:Q4zqM7aXqm7gDQkUVLng9h?version-time=1234567890&a=b#abc-123"
+            f"{DID_PREFIX}:Q4zqM7aXqm7gDQkUVLng9h?version-time=1234567890&a=b#abc-123"
         )
         JWS_HEADER_KID["validate"](
-            "did:sov:Q4zqM7aXqm7gDQkUVLng9h;foo:bar=low;a=b?version-id=1&a=b#abc-123"
+            f"{DID_PREFIX}:Q4zqM7aXqm7gDQkUVLng9h;foo:bar=low;a=b?version-id=1&a=b#abc-123"
         )
 
     def test_jwt(self):

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -15,9 +15,8 @@ from ..revocation.models.revocation_registry import RevocationRegistry
 from ..wallet.did_posture import DIDPosture as DIDPostureEnum
 
 B58 = alphabet if isinstance(alphabet, str) else alphabet.decode("ascii")
-DID_PREFIX_L = "did"
 DID_PREFIX_R = "ssw"
-DID_PREFIX = f"{DID_PREFIX_L}:{DID_PREFIX_R}"
+DID_PREFIX = f"did:{DID_PREFIX_R}"
 
 
 class IntEpoch(Range):

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -15,6 +15,9 @@ from ..revocation.models.revocation_registry import RevocationRegistry
 from ..wallet.did_posture import DIDPosture as DIDPostureEnum
 
 B58 = alphabet if isinstance(alphabet, str) else alphabet.decode("ascii")
+DID_PREFIX_L = "did"
+DID_PREFIX_R = "ssw"
+DID_PREFIX = f"{DID_PREFIX_L}:{DID_PREFIX_R}"
 
 
 class IntEpoch(Range):
@@ -131,8 +134,8 @@ class IndyRevRegSize(Range):
 class JWSHeaderKid(Regexp):
     """Validate value against JWS header kid."""
 
-    EXAMPLE = "did:sov:LjgpST2rjsoxYegQDRm7EL#keys-4"
-    PATTERN = rf"^did:(?:key:z[{B58}]+|sov:[{B58}]{{21,22}}(;.*)?(\?.*)?#.+)$"
+    EXAMPLE = f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#keys-4"
+    PATTERN = rf"^did:(?:key:z[{B58}]+|{DID_PREFIX_R}:[{B58}]{{21,22}}(;.*)?(\?.*)?#.+)$"
 
     def __init__(self):
         """Initializer."""
@@ -194,14 +197,14 @@ class IndyDID(Regexp):
     """Validate value against indy DID."""
 
     EXAMPLE = "WgWxqztrNooG92RXvxSTWv"
-    PATTERN = rf"^(did:sov:)?[{B58}]{{21,22}}$"
+    PATTERN = rf"^({DID_PREFIX}:)?[{B58}]{{21,22}}$"
 
     def __init__(self):
         """Initializer."""
 
         super().__init__(
             IndyDID.PATTERN,
-            error="Value {input} is not an indy decentralized identifier (DID)",
+            error="Value {input} is not an ssw decentralized identifier (DID)",
         )
 
 

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -17,6 +17,7 @@ from ....connections.util import mediation_record_if_id
 from ....core.error import BaseError
 from ....core.profile import ProfileSession
 from ....messaging.responder import BaseResponder
+from ....messaging.valid import DID_PREFIX
 from ....protocols.routing.v1_0.manager import RoutingManager
 from ....storage.error import StorageError, StorageNotFoundError
 from ....transport.inbound.receipt import MessageReceipt
@@ -91,7 +92,7 @@ class ConnectionManager(BaseConnectionManager):
             {
                 "@type": "https://didcomm.org/connections/1.0/invitation",
                 "label": "Alice",
-                "did": "did:sov:QmWbsNYhMrjHiqZDTUTEJs"
+                "did": "did:ssw:QmWbsNYhMrjHiqZDTUTEJs"
             }
 
         Or, in the case of a peer DID:
@@ -159,7 +160,7 @@ class ConnectionManager(BaseConnectionManager):
 
             # FIXME - allow ledger instance to format public DID with prefix?
             invitation = ConnectionInvitation(
-                label=my_label, did=f"did:sov:{public_did.did}", image_url=image_url
+                label=my_label, did=f"{DID_PREFIX}:{public_did.did}", image_url=image_url
             )
 
             # Add mapping for multitenant relaying.

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -92,7 +92,7 @@ class ConnectionManager(BaseConnectionManager):
             {
                 "@type": "https://didcomm.org/connections/1.0/invitation",
                 "label": "Alice",
-                "did": "did:ssw:QmWbsNYhMrjHiqZDTUTEJs"
+                "did": "did:sov:QmWbsNYhMrjHiqZDTUTEJs"
             }
 
         Or, in the case of a peer DID:

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -11,6 +11,7 @@ from ....core.error import BaseError
 from ....core.profile import ProfileSession
 from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....messaging.responder import BaseResponder
+from ....messaging.valid import DID_PREFIX
 from ....storage.error import StorageNotFoundError
 from ....transport.inbound.receipt import MessageReceipt
 from ....wallet.base import BaseWallet
@@ -260,7 +261,7 @@ class DIDXManager(BaseConnectionManager):
                 filter(None, [base_mediation_record, mediation_record])
             ),
         )
-        pthid = conn_rec.invitation_msg_id or f"did:sov:{conn_rec.their_public_did}"
+        pthid = conn_rec.invitation_msg_id or f"{DID_PREFIX}:{conn_rec.their_public_did}"
         attach = AttachDecorator.from_indy_dict(did_doc.serialize())
         await attach.data.sign(my_info.verkey, wallet)
         if not my_label:

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -20,6 +20,7 @@ from ....messaging.responder import BaseResponder
 from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....ledger.base import BaseLedger
 from ....ledger.error import LedgerError
+from ....messaging.valid import DID_PREFIX
 from ....multitenant.manager import MultitenantManager
 from ....storage.error import StorageNotFoundError
 from ....transport.inbound.receipt import MessageReceipt
@@ -210,7 +211,7 @@ class OutOfBandManager(BaseConnectionManager):
                 label=my_label or self._session.settings.get("default_label"),
                 handshake_protocols=handshake_protocols,
                 request_attach=message_attachments,
-                service=[f"did:sov:{public_did.did}"],
+                service=[f"{DID_PREFIX}:{public_did.did}"],
             )
             keylist_updates = await mediation_mgr.add_key(
                 public_did.verkey, keylist_updates

--- a/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
@@ -17,6 +17,7 @@ from .....ledger.base import BaseLedger
 from .....messaging.decorators.attach_decorator import AttachDecorator
 from .....messaging.responder import BaseResponder, MockResponder
 from .....messaging.util import str_to_datetime, str_to_epoch
+from .....messaging.valid import DID_PREFIX
 from .....multitenant.manager import MultitenantManager
 from .....protocols.connections.v1_0.manager import ConnectionManager
 from .....protocols.coordinate_mediation.v1_0.models.mediation_record import (
@@ -272,7 +273,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 DIDCommPrefix.qualify_current(HSProto.RFC23.name)
                 in invi_rec.invitation["handshake_protocols"]
             )
-            assert invi_rec.invitation["service"] == [f"did:sov:{TestConfig.test_did}"]
+            assert invi_rec.invitation["service"] == [f"{DID_PREFIX}:{TestConfig.test_did}"]
 
     async def test_create_invitation_mediation_overwrites_routing_and_endpoint(self):
         mock_conn_rec = async_mock.MagicMock()


### PR DESCRIPTION
did:sov -> did:ssw

did:sov 는 indy DID 이며, did:ssw 로 Initial (SKT?) DID 라는 것을 나타냄

aca-py는 indy DID를 대상으로 사용함으로 did:sov 로 하드코딩되어 있었음.
DID_PREFIX 전역변수를 사용하여 did:sov 를 did:ssw 로 변경되어 사용되도록 변경 함.

**변경 포인트 (이외에 사용 되는 곳은 없는 것으로 판단)**
1. connection - public did invitation 을 생성할 때
2. out-of-band - public did invitation 을 생성할 때
3. didexchange - connection request에서 thread id가 없을 시에 public did 사용하는 로직 상
4. messaging-valid - DID 포맷 파싱 부분, JWS header kid 부분
5. ledger - nym-to-did 에서 (실제 사용되고 있지는 않음)

유닛 테스트 코드도 반영
