### PR TITLE
Move did:sov to did:ssw in diddoc

### DIFF
--- a/aries_cloudagent/connections/models/diddoc/tests/test_diddoc.py
+++ b/aries_cloudagent/connections/models/diddoc/tests/test_diddoc.py
@@ -20,6 +20,7 @@ import json
 
 from asynctest import TestCase as AsyncTestCase, mock as async_mock
 
+from aries_cloudagent.messaging.valid import DID_PREFIX
 from .. import DIDDoc, PublicKey, PublicKeyType, Service
 from ..util import canon_did, canon_ref
 
@@ -30,38 +31,38 @@ class TestDIDDoc(AsyncTestCase):
         # One authn key by reference
         dd_in = {
             "@context": "https://w3id.org/did/v1",
-            "id": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+            "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
             "publicKey": [
                 {
                     "id": "3",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC X...",
                 },
                 {
                     "id": "4",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC 9...",
                 },
                 {
                     "id": "6",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC A...",
                 },
             ],
             "authentication": [
                 {
                     "type": "RsaSignatureAuthentication2018",
-                    "publicKey": "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
+                    "publicKey": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#4",
                 }
             ],
             "service": [
                 {
                     "id": "0",
                     "type": "Agency",
-                    "serviceEndpoint": "did:sov:Q4zqM7aXqm7gDQkUVLng9h",
+                    "serviceEndpoint": f"{DID_PREFIX}:Q4zqM7aXqm7gDQkUVLng9h",
                 }
             ],
         }
@@ -107,36 +108,36 @@ class TestDIDDoc(AsyncTestCase):
         # One authn key embedded, all possible refs canonical
         dd_in = {
             "@context": "https://w3id.org/did/v1",
-            "id": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+            "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
             "publicKey": [
                 {
                     "id": "3",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC X...",
                 },
                 {
-                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
+                    "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#4",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC 9...",
                 },
             ],
             "authentication": [
                 {
                     "type": "RsaSignatureAuthentication2018",
-                    "publicKey": "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
+                    "publicKey": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#4",
                 },
                 {
-                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#6",
+                    "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#6",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC A...",
                 },
             ],
             "service": [
                 {
-                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL;0",
+                    "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL;0",
                     "type": "Agency",
                     "serviceEndpoint": "https://www.von.ca",
                 }
@@ -154,36 +155,36 @@ class TestDIDDoc(AsyncTestCase):
         # All references canonical where possible; one authn key embedded and one by reference
         dd_in = {
             "@context": "https://w3id.org/did/v1",
-            "id": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+            "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
             "publicKey": [
                 {
-                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#3",
+                    "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#3",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC X...",
                 },
                 {
-                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
+                    "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#4",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC 9...",
                 },
             ],
             "authentication": [
                 {
                     "type": "RsaSignatureAuthentication2018",
-                    "publicKey": "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
+                    "publicKey": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#4",
                 },
                 {
-                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#6",
+                    "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#6",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC A...",
                 },
             ],
             "service": [
                 {
-                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL;0",
+                    "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL;0",
                     "type": "DidMessaging",
                     "serviceEndpoint": "https://www.von.ca",
                 }
@@ -283,9 +284,9 @@ class TestDIDDoc(AsyncTestCase):
                     "publicKeyHex": "02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71",
                 },
                 {
-                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#keys-4",
+                    "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#keys-4",
                     "type": "RsaVerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyPem": "-----BEGIN PUBLIC A...",
                 },
             ],
@@ -295,7 +296,7 @@ class TestDIDDoc(AsyncTestCase):
                     "type": "DidMessaging",
                     "priority": 0,
                     "recipientKeys": ["~ZZZZZZZZZZZZZZZZ"],
-                    "serviceEndpoint": "did:sov:LjgpST2rjsoxYegQDRm7EL;1",
+                    "serviceEndpoint": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL;1",
                 },
                 {
                     "id": "1",
@@ -303,9 +304,9 @@ class TestDIDDoc(AsyncTestCase):
                     "priority": 1,
                     "recipientKeys": [
                         "~XXXXXXXXXXXXXXXX",
-                        "did:sov:LjgpST2rjsoxYegQDRm7EL#keys-1",
+                        f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#keys-1",
                     ],
-                    "routingKeys": ["did:sov:LjgpST2rjsoxYegQDRm7EL#keys-4"],
+                    "routingKeys": [f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#keys-4"],
                     "serviceEndpoint": "LjgpST2rjsoxYegQDRm7EL;2",
                 },
                 {
@@ -314,9 +315,9 @@ class TestDIDDoc(AsyncTestCase):
                     "priority": 2,
                     "recipientKeys": [
                         "~XXXXXXXXXXXXXXXX",
-                        "did:sov:LjgpST2rjsoxYegQDRm7EL#keys-1",
+                        f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#keys-1",
                     ],
-                    "routingKeys": ["did:sov:LjgpST2rjsoxYegQDRm7EL#keys-4"],
+                    "routingKeys": [f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#keys-4"],
                     "serviceEndpoint": "https://www.two.ca/two",
                 },
             ],
@@ -332,13 +333,13 @@ class TestDIDDoc(AsyncTestCase):
         )
         assert (
             "routingKeys"
-            not in dd.service["did:sov:LjgpST2rjsoxYegQDRm7EL;indy"].to_dict()
+            not in dd.service[f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL;indy"].to_dict()
         )
         assert all(
             len(dd.service[k].to_dict()["routingKeys"]) == 1
             for k in (
-                "did:sov:LjgpST2rjsoxYegQDRm7EL;1",
-                "did:sov:LjgpST2rjsoxYegQDRm7EL;2",
+                f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL;1",
+                f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL;2",
             )
         )
 
@@ -385,7 +386,7 @@ class TestDIDDoc(AsyncTestCase):
                     "id": "LjgpST2rjsoxYegQDRm7EL;indy",
                     "type": "DidMessaging",
                     "priority": 1,
-                    "recipientKeys": ["did:sov:LjgpST2rjsoxYegQDRm7EL#keys-3"],
+                    "recipientKeys": [f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL#keys-3"],
                     "serviceEndpoint": "https://www.von.ca",
                 }
             ],
@@ -399,12 +400,12 @@ class TestDIDDoc(AsyncTestCase):
         # Minimal as per W3C Example 2, draft 0.12
         dd_in = {
             "@context": "https://w3id.org/did/v1",
-            "id": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+            "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
             "authentication": [
                 {
                     "id": "LjgpST2rjsoxYegQDRm7EL#keys-1",
                     "type": "Ed25519VerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyBase58": "~XXXXXXXXXXXXXXXX",
                 }
             ],
@@ -432,7 +433,7 @@ class TestDIDDoc(AsyncTestCase):
             "authentication": [
                 {
                     "type": "Ed25519VerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyBase58": "~XXXXXXXXXXXXXXXX",
                 }
             ],
@@ -456,7 +457,7 @@ class TestDIDDoc(AsyncTestCase):
             canon_ref("not-a-DID", ref=valid_did, delimiter="#")
 
         with self.assertRaises(ValueError):
-            canon_ref(valid_did, ref="did:sov:not-a-DID", delimiter="#")
+            canon_ref(valid_did, ref=f"{DID_PREFIX}:not-a-DID", delimiter="#")
 
         urlref = (
             "https://www.clafouti-quasar.ca:8443/supply-management/fruit/index.html"
@@ -467,12 +468,12 @@ class TestDIDDoc(AsyncTestCase):
     def test_pubkey_type(self):
         dd_in = {
             "@context": "https://w3id.org/did/v1",
-            "id": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+            "id": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
             "authentication": [
                 {
                     "id": "LjgpST2rjsoxYegQDRm7EL#keys-1",
                     "type": "Ed25519VerificationKey2018",
-                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "controller": f"{DID_PREFIX}:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyBase58": "~XXXXXXXXXXXXXXXX",
                 }
             ],

--- a/aries_cloudagent/connections/models/diddoc/util.py
+++ b/aries_cloudagent/connections/models/diddoc/util.py
@@ -21,6 +21,8 @@ limitations under the License.
 from base58 import b58decode
 from urllib.parse import urlparse
 
+from aries_cloudagent.messaging.valid import DID_PREFIX
+
 
 def resource(ref: str, delimiter: str = None) -> str:
     """
@@ -40,7 +42,7 @@ def resource(ref: str, delimiter: str = None) -> str:
 
 def canon_did(uri: str) -> str:
     """
-    Convert a URI into a DID if need be, left-stripping 'did:sov:' if present.
+    Convert a URI into a DID if need be, left-stripping 'did:ssw:' if present.
 
     Args:
         uri: input URI or DID
@@ -53,7 +55,7 @@ def canon_did(uri: str) -> str:
     if ok_did(uri):
         return uri
 
-    if uri.startswith("did:sov:"):
+    if uri.startswith(f"{DID_PREFIX}:"):
         rv = uri[8:]
         if ok_did(rv):
             return rv
@@ -78,14 +80,14 @@ def canon_ref(did: str, ref: str, delimiter: str = None):
         raise ValueError("Bad DID {} cannot act as DID document identifier".format(did))
 
     if ok_did(ref):  # e.g., LjgpST2rjsoxYegQDRm7EL
-        return "did:sov:{}".format(did)
+        return "{}:{}".format(DID_PREFIX, did)
 
     if ok_did(resource(ref, delimiter)):  # e.g., LjgpST2rjsoxYegQDRm7EL#keys-1
-        return "did:sov:{}".format(ref)
+        return "{}:{}".format(DID_PREFIX, ref)
 
     if ref.startswith(
-        "did:sov:"
-    ):  # e.g., did:sov:LjgpST2rjsoxYegQDRm7EL, did:sov:LjgpST2rjsoxYegQDRm7EL#3
+        f"{DID_PREFIX}:"
+    ):  # e.g., did:ssw:LjgpST2rjsoxYegQDRm7EL, did:ssw:LjgpST2rjsoxYegQDRm7EL#3
         rv = ref[8:]
         if ok_did(resource(rv, delimiter)):
             return ref
@@ -94,7 +96,7 @@ def canon_ref(did: str, ref: str, delimiter: str = None):
     if urlparse(ref).scheme:  # e.g., https://example.com/messages/8377464
         return ref
 
-    return "did:sov:{}{}{}".format(did, delimiter if delimiter else "#", ref)  # e.g., 3
+    return "{}:{}{}{}".format(DID_PREFIX, did, delimiter if delimiter else "#", ref)  # e.g., 3
 
 
 def ok_did(token: str) -> bool:

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -92,7 +92,7 @@ class ConnectionManager(BaseConnectionManager):
             {
                 "@type": "https://didcomm.org/connections/1.0/invitation",
                 "label": "Alice",
-                "did": "did:sov:QmWbsNYhMrjHiqZDTUTEJs"
+                "did": "did:ssw:QmWbsNYhMrjHiqZDTUTEJs"
             }
 
         Or, in the case of a peer DID:


### PR DESCRIPTION
did:sov -> did:ssw

diddoc 에도 반영

**변경 포인트
1. diddoc - DIDDoc 에 들어가는 did:sov -> did:ssw 로 변경

유닛 테스트 코드도 반영

추가 기입 사항
- DID_PREFIX 전역변수 수정을 통해 did:ssw 에서 변경 가능
- @type 에 사용되는 DIDCommPrefix는 did:sov 를 사용
