### PR TITLE
Feature/add mysql support

### DIFF
--- a/aries_cloudagent/indy/sdk/wallet_plugin.py
+++ b/aries_cloudagent/indy/sdk/wallet_plugin.py
@@ -40,8 +40,10 @@ def load_postgres_plugin(storage_config, storage_creds, raise_exc=False):
                 raise SystemExit(1)
 
         LOGGER.info("Initializing postgres wallet")
-        stg_lib = cdll.LoadLibrary("libindystrgpostgres" + file_ext())
-        result = stg_lib.postgresstorage_init()
+        #stg_lib = cdll.LoadLibrary("libindystrgpostgres" + file_ext())
+        #result = stg_lib.postgresstorage_init()
+        stg_lib = cdll.LoadLibrary("libmysqlstorage" + file_ext())
+        result = stg_lib.mysql_storage_init()
         if result != 0:
             LOGGER.error("Error unable to load postgres wallet storage: %s", result)
             if raise_exc:

--- a/aries_cloudagent/indy/sdk/wallet_plugin.py
+++ b/aries_cloudagent/indy/sdk/wallet_plugin.py
@@ -40,10 +40,8 @@ def load_postgres_plugin(storage_config, storage_creds, raise_exc=False):
                 raise SystemExit(1)
 
         LOGGER.info("Initializing postgres wallet")
-        #stg_lib = cdll.LoadLibrary("libindystrgpostgres" + file_ext())
-        #result = stg_lib.postgresstorage_init()
-        stg_lib = cdll.LoadLibrary("libmysqlstorage" + file_ext())
-        result = stg_lib.mysql_storage_init()
+        stg_lib = cdll.LoadLibrary("libindystrgpostgres" + file_ext())
+        result = stg_lib.postgresstorage_init()
         if result != 0:
             LOGGER.error("Error unable to load postgres wallet storage: %s", result)
             if raise_exc:
@@ -63,3 +61,40 @@ def load_postgres_plugin(storage_config, storage_creds, raise_exc=False):
         LOADED = True
 
         LOGGER.info("Success, loaded postgres wallet storage")
+
+
+def load_mysql_plugin(storage_config, storage_creds, raise_exc=False):
+    """Load mysql dll and configure mysql wallet."""
+    global LOADED, LOGGER
+
+    if not LOADED:
+        LOGGER.info(
+            "Checking input mysql storage_config and storage_creds arguments"
+        )
+        try:
+            json.loads(storage_config)
+            json.loads(storage_creds)
+        except json.decoder.JSONDecodeError:
+            LOGGER.error(
+                "Invalid stringified JSON input, check storage_config and storage_creds"
+            )
+            if raise_exc:
+                raise OSError(
+                    "Invalid stringified JSON input, "
+                    "check storage_config and storage_creds"
+                )
+            else:
+                raise SystemExit(1)
+
+        LOGGER.info("Initializing mysql wallet")
+        stg_lib = cdll.LoadLibrary("libmysqlstorage" + file_ext())
+        result = stg_lib.mysql_storage_init()
+        if result != 0:
+            LOGGER.error("Error unable to load mysql wallet storage: %s", result)
+            if raise_exc:
+                raise OSError(f"Error unable to load mysql wallet storage: {result}")
+            else:
+                raise SystemExit(1)
+        LOADED = True
+
+        LOGGER.info("Success, loaded mysql wallet storage")

--- a/aries_cloudagent/indy/sdk/wallet_setup.py
+++ b/aries_cloudagent/indy/sdk/wallet_setup.py
@@ -59,6 +59,7 @@ class IndyWalletConfig:
 
         if self.storage_type == "postgres_storage":
             load_postgres_plugin(self.storage_config, self.storage_creds)
+            self.storage_type = "mysql"
 
     @property
     def wallet_config(self) -> dict:

--- a/aries_cloudagent/indy/sdk/wallet_setup.py
+++ b/aries_cloudagent/indy/sdk/wallet_setup.py
@@ -16,7 +16,7 @@ from ...core.error import ProfileError, ProfileDuplicateError, ProfileNotFoundEr
 from ...core.profile import Profile
 
 from .error import IndyErrorHandler
-from .wallet_plugin import load_postgres_plugin
+from .wallet_plugin import load_postgres_plugin, load_mysql_plugin
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +59,8 @@ class IndyWalletConfig:
 
         if self.storage_type == "postgres_storage":
             load_postgres_plugin(self.storage_config, self.storage_creds)
-            self.storage_type = "mysql"
+        elif self.storage_type == "mysql":
+            load_mysql_plugin(self.storage_config, self.storage_creds)
 
     @property
     def wallet_config(self) -> dict:

--- a/docker/Dockerfile.run-wait
+++ b/docker/Dockerfile.run-wait
@@ -1,4 +1,4 @@
-FROM bcgovimages/von-image:py36-1.15-0
+FROM sktston/initial-image:py36-1.15-0
 
 ENV ENABLE_PTVSD 0
 


### PR DESCRIPTION
postgres 와 유사하게 mysql storage type을 설정하여 mysql 을 사용할 수 있도록 기능 추가

argument 예시
```
--wallet-storage-type
mysql
--wallet-storage-config
{\"db_name\":\"wallet\",\"port\":3306,\"write_host\":\"localhost\",\"read_host\":\"localhost\"}
--wallet-storage-creds
{\"user\":\"mysql\",\"pass\":\"mysecretpassword\"}
```