### PR TITLE
Ignore the logs of /status/ready and /status/live

### DIFF
--- a/aries_cloudagent/config/logging.py
+++ b/aries_cloudagent/config/logging.py
@@ -2,7 +2,7 @@
 
 import logging
 from io import TextIOWrapper
-from logging.config import fileConfig
+from logging.config import fileConfig, dictConfig
 from typing import TextIO
 
 import pkg_resources
@@ -35,6 +35,18 @@ def load_resource(path: str, encoding: str = None) -> TextIO:
         pass
 
 
+class IgnoreFilter(logging.Filter):
+    def __init__(self, param=None):
+        self.param = param
+
+    def filter(self, record):
+        if self.param is None:
+            allow = True
+        else:
+            allow = self.param not in record.msg
+        return allow
+
+
 class LoggingConfigurator:
     """Utility class used to configure logging and print an informative start banner."""
 
@@ -65,6 +77,41 @@ class LoggingConfigurator:
         else:
             logging.basicConfig(level=logging.WARNING)
             logging.root.warning(f"Logging config file not found: {config_path}")
+
+        aiohttp_logging_config = {
+            'version': 1,
+            'disable_existing_loggers': False,
+            'formatters': {
+                'standard': {
+                    'format': '%(asctime)s %(name)s %(levelname)s %(message)s'
+                },
+            },
+            'filters': {
+                'ignore_ready': {
+                    '()': IgnoreFilter,
+                    'param': 'GET /status/ready HTTP',
+                },
+                'ignore_live': {
+                    '()': IgnoreFilter,
+                    'param': 'GET /status/live HTTP',
+                },
+            },
+            'handlers': {
+                'aiohttp_handler': {
+                    'formatter': 'standard',
+                    'class': 'logging.StreamHandler',
+                    'filters': ['ignore_ready', 'ignore_live'],
+                },
+            },
+            'loggers': {
+                'aiohttp': {
+                    'handlers': ['aiohttp_handler'],
+                    'level': 'INFO',
+                    'propagate': False
+                },
+            }
+        }
+        dictConfig(aiohttp_logging_config)
 
         if log_file:
             logging.root.handlers.clear()


### PR DESCRIPTION
Filter 기능을 사용하여 aiohttp 라이브러리에서 호출하는 /status/ready, /status/live 로그를 출력 제외 시킴.

히스토리

config_file 로 시도하여 보았으나, filter 기능을 사용할 수 없었음.
DictConfig 에 들어가는 Dict 타입의 설정 파일을 json으로 외부에서 주입하려 시도하였으나, Filter class를 주입할 수 없었음
별수 없이, 하드 코딩 됨.


Signed-off-by: Ethan Sung <baegjae@gmail.com>