### PR TITLE
Fetch setting of profile from wallet_record

### DIFF
--- a/aries_cloudagent/multitenant/manager.py
+++ b/aries_cloudagent/multitenant/manager.py
@@ -172,6 +172,9 @@ class MultitenantManager:
             profile, _ = await wallet_config(context, provision=provision)
             self._instances[wallet_id] = profile
 
+        # FIXME: Scale-out issue - to get label, image_url and webhook_urls (maybe more?) from db record
+        await self.fetch_wallet(wallet_id)
+
         return self._instances[wallet_id]
 
     async def create_wallet(
@@ -310,6 +313,35 @@ class MultitenantManager:
             )
 
             await wallet.delete_record(session)
+
+    # FIXME: Scale-out issue - to get label, image_url and webhook_urls (maybe more?) from db record
+    async def fetch_wallet(
+        self,
+        wallet_id: str
+    ):
+        """Get a existing wallet record and fetch profile settings.
+
+        Args:
+            wallet_id: The wallet id of the wallet record
+
+        Returns:
+
+        """
+        # get wallet_record
+        async with self._profile.session() as session:
+            wallet_record = await WalletRecord.retrieve_by_id(session, wallet_id)
+
+        # fetch profile only if loaded
+        if wallet_id in self._instances:
+            profile = self._instances[wallet_id]
+            profile.settings.update(wallet_record.settings)
+
+            extra_settings = {
+                "admin.webhook_urls": self.get_webhook_urls(
+                    self._profile.context, wallet_record
+                ),
+            }
+            profile.settings.update(extra_settings)
 
     async def add_key(
         self, wallet_id: str, recipient_key: str, *, skip_if_exists: bool = False


### PR DESCRIPTION
https://github.com/sktston/aries-cloudagent-python/issues/26 해결방안

profile을 가져 올 때 마다 (API, incoming message), profile의 settings를 fetch (label, image_url, webhook_urls 갱신 위함)
wallet_record UPDATE의 경우, 이슈 없이 오버헤드 없이 동작하나,
wallet_record UPDATE의 경우, Garbage issue 가 있음 아래 글 참고 (동작에는 무관함 - 정상동작)

        # FIXME: Scale-out support
        # - wallet_record UPDATE case: OK
        #   - fetch label, image_url and webhook_urls from db record
        # - wallet_record DELETE case: Garbage issue
        #   - deleted profiles remain in self._instances
        #     (all servers except a server that requested wallet remove API)
        #     below PR can solve this
        #     https://github.com/hyperledger/aries-cloudagent-python/pull/928

