### PR TITLE
Revert disable_cache

### DIFF
--- a/aries_cloudagent/cache/base.py
+++ b/aries_cloudagent/cache/base.py
@@ -127,7 +127,6 @@ class CacheKeyLock:
 
     async def set_result(self, value: Any, ttl: int = None):
         """Set the result, updating the cache and any waiters."""
-        return  # FIXME: disable cache for results
         if self.done and value:
             raise CacheError("Result already set")
         self._future.set_result(value)

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -176,7 +176,6 @@ class BaseRecord(BaseModel):
             value: The value to cache
             ttl: The cache ttl
         """
-        return  # FIXME: disable cache for records
         if not cache_key:
             return
         cache = session.inject(BaseCache, required=False)


### PR DESCRIPTION
cache 에 담기는 내용이 record가 아니라, record를 찾기 위한 record_id 로 변경이 있었음. (main 브랜치)
따라서 cache를 사용한다 하더라도, 최신 record를 읽어드리기 때문에,
cache를 사용 안 하도록 하는 기존의 patch는 필요 없어졌음. 

Signed-off-by: Ethan Sung <baegjae@gmail.com>