### PR TITLE
Allow schema sequence number 0 at credential definition id

### DIFF
--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -300,7 +300,7 @@ class IndyCredDefId(Regexp):
         rf"^([{B58}]{{21,22}})"  # issuer DID
         f":3"  # cred def id marker
         f":CL"  # sig alg
-        rf":(([1-9][0-9]*)|([{B58}]{{21,22}}:2:.+:[0-9.]+))"  # schema txn / id
+        rf":(([0-9]*)|([{B58}]{{21,22}}:2:.+:[0-9.]+))"  # schema txn / id
         f":(.+)?$"  # tag
     )
 


### PR DESCRIPTION
이니셜 모바일 가입 증명 credential definition id 에서 schema sequence number 가 0 으로 설정되어 있어,
이번 merge에서 추가된, credential definition id 검증 로직 중,
schema sequence number 를 0 허용하도록 수정

Signed-off-by: Ethan Sung <baegjae@gmail.com>